### PR TITLE
Fix Windows 11 being reported as Windows 10

### DIFF
--- a/Win32.pm
+++ b/Win32.pm
@@ -560,7 +560,7 @@ sub _GetOSName {
 	elsif ($major == 10) {
             if ($producttype == VER_NT_WORKSTATION) {
                 # Build numbers from https://en.wikipedia.org/wiki/Windows_10_version_history
-                $os = '10';
+                $os = $build < 22000 ? '10' : '11';
                 if (9841 <= $build && $build <= 10240) {
                     $desc = " Version 1507";
                     $desc .= " (Preview Build $build)" if $build < 10240;


### PR DESCRIPTION
When running on Windows 11:
- GetOSName now returns "Win11" instead of "Win10"
- GetOSDisplayName now returns "Windows 11 Build ..." instead of "Windows 10 Build ..."